### PR TITLE
SAPIイベントを使うかどうかのチェックボックスを追加し、それを参照するように変更。

### DIFF
--- a/SAPIForVOICEVOX/VoiceVoxTTSEngine.cs
+++ b/SAPIForVOICEVOX/VoiceVoxTTSEngine.cs
@@ -226,7 +226,7 @@ namespace SAPIForVOICEVOX
                         //SAPIイベント
                         if (generalSetting.useSspiEvent ?? false)
                         {
-                            AddEventToSAPI(pOutputSite, currentTextList, str, writtenWavLength);
+                            AddEventToSAPI(pOutputSite, currentTextList.pTextStart, str, writtenWavLength);
                         }
 
                         //英単語をカナへ置換
@@ -326,18 +326,18 @@ namespace SAPIForVOICEVOX
         /// <summary>
         /// SAPIへイベントを追加します。
         /// </summary>
-        /// <param name="pOutputSite"></param>
-        /// <param name="currentTextList"></param>
-        /// <param name="str"></param>
+        /// <param name="outputSite"></param>
+        /// <param name="textList"></param>
+        /// <param name="speakTargetText"></param>
         /// <param name="writtenWavLength"></param>
-        private void AddEventToSAPI(ISpTTSEngineSite pOutputSite, SPVTEXTFRAG currentTextList, string str, ulong writtenWavLength)
+        private void AddEventToSAPI(ISpTTSEngineSite outputSite, string allText, string speakTargetText, ulong writtenWavLength)
         {
-            pOutputSite.GetEventInterest(out ulong ulongValue);
+            outputSite.GetEventInterest(out ulong ulongValue);
             List<SPEVENT> sPEVENTList = new List<SPEVENT>();
             //プラットフォームのビット数に応じて、wParamとlParamの型が異なるので、分岐
 #if x64
-            ulong wParam = (ulong)str.Length;
-            long lParam = currentTextList.pTextStart.IndexOf(str);
+            ulong wParam = (ulong)speakTargetText.Length;
+            long lParam = allText.IndexOf(speakTargetText);
 #else
             uint wParam = (uint)str.Length;
             int lParam = currentTextList.pTextStart.IndexOf(str);
@@ -367,7 +367,7 @@ namespace SAPIForVOICEVOX
             if (sPEVENTList.Count > 0)
             {
                 SPEVENT[] sPEVENTArr = sPEVENTList.ToArray();
-                pOutputSite.AddEvents(ref sPEVENTArr[0], (uint)sPEVENTArr.Length);
+                outputSite.AddEvents(ref sPEVENTArr[0], (uint)sPEVENTArr.Length);
             }
         }
 

--- a/Setting/Model/GeneralSetting.cs
+++ b/Setting/Model/GeneralSetting.cs
@@ -31,5 +31,10 @@ namespace Setting
         /// </summary>
         public bool? shouldNotifyEngineError = true;
 
+        /// <summary>
+        /// SAPIイベントを使うかどうか
+        /// </summary>
+        public bool? useSspiEvent = true;
+
     }
 }

--- a/Setting/View/MainWindow.xaml
+++ b/Setting/View/MainWindow.xaml
@@ -32,9 +32,10 @@
                                 <RadioButton x:Name="parCharacterRadioButton" Margin="3" Content="キャラクター毎に設定する"  IsChecked="{Binding SynthesisSettingMode, ConverterParameter=EachCharacter, Converter={StaticResource SettinModeConverter}}"/>
                             </StackPanel>
                         </GroupBox>
-                        <GroupBox DockPanel.Dock="Top" Header="エラーハンドリング">
+                        <GroupBox DockPanel.Dock="Top" Header="高度な設定">
                             <StackPanel>
-                                <CheckBox Content="エンジンエラーを通知する。" Margin="3" IsChecked="{Binding ShouldNotifyEngineError}"/>
+                                <CheckBox Content="エンジンエラーを通知する" Margin="3" IsChecked="{Binding ShouldNotifyEngineError}"/>
+                                <CheckBox Content="SAPIイベントを使用する" Margin="3" IsChecked="{Binding UseSapiEvent}" ToolTip="N Airで使用する場合はチェックを外してください"/>
                             </StackPanel>
                         </GroupBox>
                         <Button x:Name="resetButton" DockPanel.Dock="Bottom" Margin="3" HorizontalAlignment="Left" Content="初期状態へ戻す"/>

--- a/Setting/ViewModel/ViewModel.cs
+++ b/Setting/ViewModel/ViewModel.cs
@@ -130,6 +130,20 @@ namespace Setting
             }
         }
 
+        /// <summary>
+        /// SAPIイベントを通知するかどうかを取得、設定します。
+        /// </summary>
+        public bool? UseSapiEvent
+        {
+            get => generalSetting.useSspiEvent;
+            set
+            {
+                if (generalSetting.useSspiEvent == value) return;
+                generalSetting.useSspiEvent = value;
+                RaisePropertyChanged();
+            }
+        }
+
 
         #endregion
 


### PR DESCRIPTION
設定画面にSAPIイベントを使うかどうかのチェックボックスを追加。
エラー通知と一緒に、高度な設定グループに配置。

イベントを使うかどうかの値を参照して、分岐するように変更。