### PR TITLE
レジストリ登録するときにカレントディレクトリをしていする

### DIFF
--- a/SetupCustomActions/CustomActions.cs
+++ b/SetupCustomActions/CustomActions.cs
@@ -77,6 +77,8 @@ namespace SetupCustomActions
             process.StartInfo.Arguments = arguments;
             // ウィンドウを表示しない
             process.StartInfo.CreateNoWindow = true;
+            // カレントディレクトリ指定
+            process.StartInfo.WorkingDirectory = installDirectory;
 
             // 起動
             process.Start();


### PR DESCRIPTION
システムドライブ以外のインストールできるかもとの期待で、
カレントディレクトリを指定するように変更。
未テスト。