### PR TITLE
レジストリの名前につける連番を3桁に変更

### DIFF
--- a/StyleRegistrationTool/ViewModel/MainViewModel.cs
+++ b/StyleRegistrationTool/ViewModel/MainViewModel.cs
@@ -601,7 +601,7 @@ namespace StyleRegistrationTool.ViewModel
             {
                 for (int i = 0; i < SapiStyles.Count(); i++)
                 {
-                    using (RegistryKey voiceVoxRegkey = regTokensKey.CreateSubKey("VOICEVOX" + i.ToString()))
+                    using (RegistryKey voiceVoxRegkey = regTokensKey.CreateSubKey("VOICEVOX" + i.ToString("000")))
                     {
                         voiceVoxRegkey.SetValue("", SapiStyles[i].SpaiName);
                         voiceVoxRegkey.SetValue("411", SapiStyles[i].SpaiName);


### PR DESCRIPTION
レジストリの並びが、文字列の順番で、1の次が10だった。
1の次に2が来るようにしたいので、前に0を付けて、3桁で表示されるようにした。

ref #70 